### PR TITLE
add a FileDir option

### DIFF
--- a/envcfg.go
+++ b/envcfg.go
@@ -64,6 +64,7 @@ type Envcfg struct {
 
 	envVarName string
 	configFile string
+	fileDir    string
 
 	envKey          string
 	hostKey         string
@@ -173,7 +174,14 @@ func (ec *Envcfg) GetKey(key string) string {
 				}
 
 			case "file":
-				if buf, err := ioutil.ReadFile(val); err == nil {
+				path := val
+				// If this is a relative path and a
+				// FileDir was given, use that as the
+				// base instead of the current dir.
+				if !filepath.IsAbs(path) && ec.fileDir != "" {
+					path = filepath.Join(ec.fileDir, path)
+				}
+				if buf, err := ioutil.ReadFile(path); err == nil {
 					val = string(buf)
 				}
 			}

--- a/opts.go
+++ b/opts.go
@@ -18,6 +18,14 @@ func ConfigFile(path string) Option {
 	}
 }
 
+// FileDir is an option that sets the directory path from which relative
+// files will be read. The default is the current directory.
+func FileDir(path string) Option {
+	return func(ec *Envcfg) {
+		ec.fileDir = path
+	}
+}
+
 // KeyFilter is an option that adds a key filter.
 func KeyFilter(key string, f Filter) Option {
 	return func(ec *Envcfg) {


### PR DESCRIPTION
So that one can load an env/config file from a different dir, while
keeping relative file paths working, without having to bother with
os.Chdir.

This is useful when running tests in sub-packages, for example.