### PR TITLE
Convert file dir to configurable key entry

### DIFF
--- a/examples/sample.config
+++ b/examples/sample.config
@@ -6,3 +6,12 @@ host="$HOST||example.com"                        ; hostname
 port="$PORT||8443"                               ; port
 certs="$CERTS||./env/certs"                      ; certificate directory cache
 certProvider="dns:godo:<domain>:<email>:<token>" ; certificate provider
+fileEncodingPath="$FILEPATH||."                  ; path for loading "file" encoded values (for non-absolute paths only)
+
+[google]
+creds="$GOOGLECREDS||env/gsa.json||file"         ; "file" encoded gsa credentials
+																								 ; since server.fileEncodingPath has been set,
+																								 ; then the path will be ./env/gsa.json
+
+[example]
+b64value="$B64VALUE||e30K||base64"               ; "base64" encoded value

--- a/opts.go
+++ b/opts.go
@@ -18,14 +18,6 @@ func ConfigFile(path string) Option {
 	}
 }
 
-// FileDir is an option that sets the directory path from which relative
-// files will be read. The default is the current directory.
-func FileDir(path string) Option {
-	return func(ec *Envcfg) {
-		ec.fileDir = path
-	}
-}
-
 // KeyFilter is an option that adds a key filter.
 func KeyFilter(key string, f Filter) Option {
 	return func(ec *Envcfg) {
@@ -58,5 +50,12 @@ func PortKey(key string) Option {
 func CertPathKey(key string) Option {
 	return func(ec *Envcfg) {
 		ec.certPathKey = key
+	}
+}
+
+// FileEncodingPathKey is an option that sets the file encoding path key.
+func FileEncodingPathKey(key string) Option {
+	return func(ec *Envcfg) {
+		ec.fileEncodingPathKey = key
 	}
 }


### PR DESCRIPTION
This adds the FileEncodingPath func to the Envcfg type, and adds
the associated keys and default configuration.

Should be backwards compatible with existing envcfg deployments.