### PR TITLE
envcfg: add key checker for section

### DIFF
--- a/envcfg.go
+++ b/envcfg.go
@@ -303,6 +303,28 @@ func (ec *Envcfg) MustInt(key string) int {
 	return i
 }
 
+// KeyExist checks if the key exists in the section, if it is found in the
+// section it returns true, else false 
+func (ec *Envcfg) KeyExist(sectionNameAndKey string) bool {
+	name, key := ec.config.NameSplitFunc(sectionNameAndKey)
+	section := ec.config.GetSection(name)
+	if section == nil {
+		return false
+	}
+
+	sectionKeys := section.Keys()
+	if len(sectionKeys) == 0 {
+		return false 
+	}
+
+	for _, sKey := range sectionKeys {
+		if strings.ToLower(key) == sKey {
+			return true
+		}
+	}
+	return false 
+}
+
 // Env retrieves the value for the runtime environment key.
 func (ec *Envcfg) Env() string {
 	if env := ec.GetKey(ec.envKey); env != "" {

--- a/envcfg_test.go
+++ b/envcfg_test.go
@@ -1,9 +1,34 @@
 package envcfg
 
 import (
+	"fmt"
+	"log"
 	"testing"
 )
 
 func TestEmpty(t *testing.T) {
 
+}
+
+func TestKeyExist(t *testing.T) {
+	const (
+		serverHostKey        = "server.host"
+		serverNonexistingKey = "server.nonexisting"
+		nonExistingSection   = "nonexisting.section"
+	)
+
+	config, err := New(ConfigFile("_example/sample.config"))
+	if err != nil {
+		log.Fatalf("error initializing config: %v", err)
+	}
+
+	if !config.KeyExist(serverHostKey) {
+		t.Fatalf("%q should exist", serverHostKey)
+	}
+	if config.KeyExist(serverNonexistingKey) {
+		t.Fatalf("%q shouldn't exists", serverNonexistingKey)
+	}
+	if config.KeyExist(nonExistingSection) {
+		t.Fatalf("%q shouldn't exists", nonExistingSection)
+	}
 }


### PR DESCRIPTION
Sometimes we only need to check if a key is present in a section, f.e if
we have sections bank1 bank2 and they share id and secret but there is a
third key which is not shared, if we iterate over those two banks we
want to know which has the third key and which does not.

[CORE-997] #done

[CORE-997]: https://brankas.atlassian.net/browse/CORE-997